### PR TITLE
Load config via shared script to avoid unsafe functions

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,4 +1,4 @@
-local config = loadfile('config.lua')()
+local config = CONFIG
 local showPanel = false
 local sx, sy = guiGetScreenSize()
 local panelX, panelY = config.shop.panel.x * sx, config.shop.panel.y * sy

--- a/config.lua
+++ b/config.lua
@@ -1,4 +1,4 @@
-return {
+CONFIG = {
     aclGroup = "SAMU",
     disease = {
         startMinutes = 30, -- minutos para começar a ficar doente

--- a/meta.xml
+++ b/meta.xml
@@ -1,5 +1,6 @@
 <meta>
     <info author="ChatGPT" name="Vaccine System" type="script" />
+    <script src="config.lua" type="shared" />
     <script src="server.lua" type="server" />
     <script src="client.lua" type="client" />
 </meta>

--- a/server.lua
+++ b/server.lua
@@ -1,4 +1,4 @@
-local config = loadfile('config.lua')()
+local config = CONFIG
 local diseaseTimers = {}
 local pendingOffers = {}
 


### PR DESCRIPTION
## Summary
- define configuration in a shared Lua script and include it for both client and server
- remove unsafe `loadfile` usage and read settings from the shared `CONFIG` table

## Testing
- `luac -p server.lua client.lua config.lua`
- `xmllint --noout meta.xml`


------
https://chatgpt.com/codex/tasks/task_e_688d2d82eaa083329dd7d02bc84456cc