### PR TITLE
Add vaccine panel improvements and console commands

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -2,28 +2,48 @@ local config = CONFIG
 local showPanel = false
 local sx, sy = guiGetScreenSize()
 local panelX, panelY = config.shop.panel.x * sx, config.shop.panel.y * sy
-local panelW, panelH = 400, 250
+local panelW, panelH = 400, 260
 local font = 'default-bold'
+local colors = config.shop.buttonColors
+local buyBtn = {x = panelX + 50, y = panelY + 160, w = panelW - 100, h = 40}
+local exitBtn = {x = panelX + 50, y = panelY + 210, w = panelW - 100, h = 40}
 
-local function drawPanel()
+local drawPanel, clickPanel, keyPanel
+
+local function closePanel()
+    showPanel = false
+    showCursor(false)
+    removeEventHandler('onClientRender', root, drawPanel)
+    removeEventHandler('onClientClick', root, clickPanel)
+    removeEventHandler('onClientKey', root, keyPanel)
+end
+
+function drawPanel()
     dxDrawRectangle(panelX, panelY, panelW, panelH, tocolor(0,0,0,200))
     dxDrawText('Hospital - Vacinas', panelX, panelY+20, panelX+panelW, panelY+60, tocolor(255,255,255), 1.2, font, 'center', 'top')
     dxDrawText('Comprar proteção por '..config.shop.protectionHours..'h', panelX, panelY+80, panelX+panelW, panelY+120, tocolor(255,255,255), 1, font, 'center', 'top')
-    dxDrawRectangle(panelX+50, panelY+160, panelW-100, 50, tocolor(0,150,0))
-    dxDrawText('Comprar - $'..config.shop.price, panelX+50, panelY+160, panelX+panelW-50, panelY+210, tocolor(255,255,255), 1.2, font, 'center', 'center')
+    dxDrawRectangle(buyBtn.x, buyBtn.y, buyBtn.w, buyBtn.h, tocolor(colors.buy.r, colors.buy.g, colors.buy.b))
+    dxDrawText('Comprar - $'..config.shop.price, buyBtn.x, buyBtn.y, buyBtn.x+buyBtn.w, buyBtn.y+buyBtn.h, tocolor(255,255,255), 1.2, font, 'center', 'center')
+    dxDrawRectangle(exitBtn.x, exitBtn.y, exitBtn.w, exitBtn.h, tocolor(colors.exit.r, colors.exit.g, colors.exit.b))
+    dxDrawText('Sair', exitBtn.x, exitBtn.y, exitBtn.x+exitBtn.w, exitBtn.y+exitBtn.h, tocolor(255,255,255), 1.2, font, 'center', 'center')
 end
 
-local function clickPanel(btn, state)
+function clickPanel(btn, state)
     if btn == 'left' and state == 'up' and showPanel then
         local x, y = getCursorPosition()
         x, y = x * sx, y * sy
-        if x >= panelX+50 and x <= panelX+panelW-50 and y >= panelY+160 and y <= panelY+210 then
+        if x >= buyBtn.x and x <= buyBtn.x+buyBtn.w and y >= buyBtn.y and y <= buyBtn.y+buyBtn.h then
             triggerServerEvent('vaccine:buy', localPlayer)
-            showPanel = false
-            showCursor(false)
-            removeEventHandler('onClientRender', root, drawPanel)
-            removeEventHandler('onClientClick', root, clickPanel)
+            closePanel()
+        elseif x >= exitBtn.x and x <= exitBtn.x+exitBtn.w and y >= exitBtn.y and y <= exitBtn.y+exitBtn.h then
+            closePanel()
         end
+    end
+end
+
+function keyPanel(btn, press)
+    if btn == 'backspace' and press and showPanel then
+        closePanel()
     end
 end
 
@@ -33,6 +53,7 @@ addEventHandler('vaccine:showShop', root, function()
     showCursor(true)
     addEventHandler('onClientRender', root, drawPanel)
     addEventHandler('onClientClick', root, clickPanel)
+    addEventHandler('onClientKey', root, keyPanel)
 end)
 
 addEvent('vaccine:effects', true)

--- a/config.lua
+++ b/config.lua
@@ -16,7 +16,16 @@ CONFIG = {
         position = {x = 1177.0, y = -1323.0, z = 14.0}, -- posição do painel no hospital
         price = 2000, -- valor da vacina comprada no painel
         protectionHours = 6, -- horas de proteção extra
-        panel = {x = 0.35, y = 0.3} -- posição do painel DX na tela
+        panel = {x = 0.35, y = 0.3}, -- posição do painel DX na tela
+        markerColor = {r = 0, g = 255, b = 0, a = 150}, -- cor do marcador do hospital
+        buttonColors = { -- cores dos botões do painel
+            buy = {r = 0, g = 150, b = 0},
+            exit = {r = 150, g = 0, b = 0}
+        }
+    },
+    commands = {
+        reset = "resetvacina",
+        set = "setvacina"
     }
 }
 


### PR DESCRIPTION
## Summary
- add configurable colors and command names to vaccine system
- allow exiting vaccine shop via button or Backspace
- provide console commands to reset or grant vaccine protection

## Testing
- `luac -p server.lua`
- `luac -p client.lua`
- `luac -p config.lua`


------
https://chatgpt.com/codex/tasks/task_e_688d3121e3248332acb5427b8b71e3d2