### PR TITLE
Improve vaccine effects and reminders

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -71,12 +71,28 @@ addEventHandler('vaccine:showShop', root, function()
     addEventHandler('onClientKey', root, keyPanel)
 end)
 
+local effectTimer
+
 addEvent('vaccine:effects', true)
 addEventHandler('vaccine:effects', root, function(state)
     if state then
-        setGameSpeed(config.disease.slowdown)
-        setCameraShakeLevel(config.disease.cameraShake)
+        if isTimer(effectTimer) then killTimer(effectTimer) end
+        effectTimer = setTimer(function()
+            if not isElement(localPlayer) then return end
+            local hp = getElementHealth(localPlayer)
+            if hp < 40 then
+                setGameSpeed(config.disease.slowdown)
+                setCameraShakeLevel(config.disease.cameraShake)
+            else
+                setGameSpeed(1)
+                setCameraShakeLevel(0)
+            end
+        end, 500, 0)
     else
+        if isTimer(effectTimer) then
+            killTimer(effectTimer)
+            effectTimer = nil
+        end
         setGameSpeed(1)
         setCameraShakeLevel(0)
     end

--- a/server.lua
+++ b/server.lua
@@ -4,6 +4,9 @@ local diseaseStartTimers = {}
 local protectionTimers = {}
 local pendingOffers = {}
 
+-- Garantir que o evento clientside esteja registrado para evitar erros
+addEvent('vaccine:effects', true)
+
 local db = dbConnect('sqlite', 'vaccines.db')
 if db then
     dbExec(db, 'CREATE TABLE IF NOT EXISTS vaccines (serial TEXT PRIMARY KEY, vaccine_expires INTEGER, sick INTEGER, disease_time INTEGER)')
@@ -60,6 +63,8 @@ local function startDisease(player)
         if isElement(player) and getElementData(player, 'vaccine.sick') then
             local health = getElementHealth(player)
             setElementHealth(player, math.max(health - config.disease.healthAmount, 0))
+            -- lembrar o jogador de procurar a vacina
+            exports['[HS]Notify_System']:notify(player, 'Você está doente! Procure um SAMU ou vá ao hospital para vacinar-se.', 'warning')
         end
     end, interval, 0)
 end


### PR DESCRIPTION
## Summary
- Fix server-side registration for `vaccine:effects` to prevent event errors
- Repeatedly notify sick players to vaccinate
- Slow players only when health drops below 40

## Testing
- `luac -p server.lua`
- `luac -p client.lua`


------
https://chatgpt.com/codex/tasks/task_e_688d4e62b92083329ab4984e72852630