### PR TITLE
Add SAMU call system with target markers

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -13,6 +13,10 @@ CONFIG = {
         protectionMinutes = 60, -- minutos de proteção após vacina do SAMU
         offerTimeout = 15000 -- tempo em ms para aceitar a oferta
     },
+    samuCall = {
+        command = "samu", -- comando para solicitar o SAMU
+        timeoutMinutes = 5 -- tempo em minutos para o chamado expirar
+    },
     shop = {
         position = {x = 1177.0, y = -1323.0, z = 14.0}, -- posição do painel no hospital
         price = 2000, -- valor da vacina comprada no painel


### PR DESCRIPTION
## Summary
- add configuration for SAMU call command and timeout
- implement `/samu` command that notifies SAMU players and sets a target marker
- remove target when SAMU reaches caller or after the configured timeout

## Testing
- `luac -p server.lua`
- `luac -p config.lua`
- `luac -p client.lua`


------
https://chatgpt.com/codex/tasks/task_e_688e1ddbed8c833284778179d736c650